### PR TITLE
Provision CM magic methods based on async CM ones

### DIFF
--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -1,0 +1,18 @@
+import asyncio
+
+from tests.utils import SampleClass
+
+
+def sync_cm():
+    with SampleClass() as obj:
+        return obj
+
+
+async def async_cm():
+    async with SampleClass() as obj:
+        return obj
+
+
+def test_context_manager():
+    assert isinstance(sync_cm(), SampleClass)
+    assert isinstance(asyncio.run(async_cm()), SampleClass)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,6 +17,12 @@ class SampleClass:
     def __init__(self):
         self._session = SampleSession()
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self._close()
+
     def sync_method(self):
         return True
 

--- a/universalasync/wrapper.py
+++ b/universalasync/wrapper.py
@@ -102,4 +102,10 @@ def wrap(source: object) -> object:
                 function = getattr(source, name)
                 setattr(source, name, async_to_sync_wraps(function))
 
+        elif name == "__aenter__" and not hasattr(source, "__enter__"):
+            setattr(source, "__enter__", async_to_sync_wraps(method))
+
+        elif name == "__aexit__" and not hasattr(source, "__exit__"):
+            setattr(source, "__exit__", async_to_sync_wraps(method))
+
     return source


### PR DESCRIPTION
Hey !

This PR implements auto-provisioning of `__enter__` and `__exit__` methods to provide an OOTB "sync" version of an object acting as an asynchronous context manager.

Note : any resource bound to an event loop and allocated in `__aenter__` **cannot** be released in `__aexit__` due to this library internals. Thus only "simple" asynchronous CMs **should** be wrapped this way 🙂

Thanks, bye 👋