### PR TITLE
Generic TypeVar for wraps decorator

### DIFF
--- a/universalasync/wrapper.py
+++ b/universalasync/wrapper.py
@@ -3,7 +3,7 @@ import functools
 import inspect
 import types
 from collections.abc import AsyncGenerator, Callable, Generator
-from typing import Any, cast, TypeVar
+from typing import Any, TypeVar, cast
 
 from universalasync.utils import get_event_loop
 

--- a/universalasync/wrapper.py
+++ b/universalasync/wrapper.py
@@ -3,7 +3,7 @@ import functools
 import inspect
 import types
 from collections.abc import AsyncGenerator, Callable, Generator
-from typing import Any, cast
+from typing import Any, cast, TypeVar
 
 from universalasync.utils import get_event_loop
 
@@ -67,7 +67,10 @@ def async_to_sync_wraps(function: Callable) -> Callable:
     return result
 
 
-def wrap(source: object) -> object:
+T = TypeVar("T")
+
+
+def wrap(source: T) -> T:
     """Convert all public async methods/properties of an object to universal methods.
 
     See :func:`async_to_sync_wraps` for more info


### PR DESCRIPTION
Use a TypeVar for wraps so IDEs know that the decorated class is the same type as it was originally